### PR TITLE
KI update

### DIFF
--- a/docs/CoasterDetails.md
+++ b/docs/CoasterDetails.md
@@ -1,0 +1,224 @@
+---
+title: Coaster Details
+date: 2024-03-21
+updated: 2025-05-05 00:00:00
+permalink: coaster-details
+categories:
+  - Roller Coasters
+excerpt: "Detailed information about my roller coaster credits!"
+---
+
+Total Coaster Credits: 103
+
+### Track Types
+
+* Steel: 80
+* Wood: 12
+* Hybrid: 11
+
+### Manufacturers
+
+* Bolliger & Mabillard: 22
+* Arrow Dynamics: 9
+* Intamin: 8
+* Vekoma: 6
+* Premier Rides: 5
+* Great Coasters International: 5
+* Philadelphia Toboggan Coasters: 5
+* Mack Rides: 4
+* Walt Disney Imagineering: 4
+* Rocky Mountain Construction: 3
+* Gerstlauer: 2
+* S&S Worldwide: 2
+* Dinn Corporation: 2
+* Zierer: 2
+* Zamperla: 4
+* Morgan: 1
+* Schwarzkopf: 1
+* Togo: 1
+* Maurer: 1
+* Dynamic Structures: 1
+* International Coasters: 1
+
+### Busch Gardens Williamsburg (Williamsburg, Virginia)
+
+12 Coasters
+
+* Loch Ness Monster - Year: 1978, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/110.htm)
+* Big Bad Wolf - Year: 1984-2009, Status: Closed, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/111.htm)
+* Drachen Fire - Year: 1992-1998, Status: Closed, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/112.htm)
+* Wild Maus - Year: 1999-2004, Status: Closed, Builder: Mack Rides, Type: Steel [RCDB Link](https://rcdb.com/455.htm)
+* Apollo's Chariot - Year: 1999, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/531.htm)
+* Alpengeist - Year: 1997, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/277.htm)
+* Griffon - Year: 2007, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/3631.htm)
+* Tempesto - Year: 2015, Status: Operating, Builder: Premier Rides, Type: Steel [RCDB Link](https://rcdb.com/12277.htm)
+* Grovers Alpine Express - Year: 2013, Status: Operating, Builder: Zierer, Type: Steel [RCDB Link](https://rcdb.com/4282.htm)
+* Verbolten - Year: 2012, Status: Operating, Builder: Zierer, Type: Steel [RCDB Link](https://rcdb.com/9463.htm)
+* InvadR - Year: 2017, Status: Operating, Builder: Great Coasters International, Type: Wood [RCDB Link](https://rcdb.com/8027.htm)
+* Pantheon - Year: 2022, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/16812.htm)
+
+### Busch Gardens Tampa (Tampa, Florida)
+
+9 Coasters
+
+* Iron Gwazi - Year: 2022, Status: Operating, Builder: Rocky Mountain Construction, Type: Hybrid [RCDB Link](https://rcdb.com/57.htm)
+* Scorpion - Year: 1980, Status: Operating, Builder: Schwarzkopf, Type: Steel [RCDB Link](https://rcdb.com/58.htm)
+* Kumba - Year: 1993, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/59.htm)
+* Montu - Year: 1996, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/60.htm)
+* Sand Serpent - Year: 2011, Status: Operating, Builder: Mack Rides, Type: Steel [RCDB Link](https://rcdb.com/61.htm)
+* SheiKra - Year: 2005, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/62.htm)
+* Cheetah Hunt - Year: 2011, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/63.htm)
+* Cobra's Curse - Year: 2016, Status: Operating, Builder: Mack Rides, Type: Steel [RCDB Link](https://rcdb.com/64.htm)
+* Tigris - Year: 2019, Status: Operating, Builder: Premier Rides, Type: Steel [RCDB Link](https://rcdb.com/65.htm)
+
+### Seaworld (Orlando, Florida)
+
+4 Coasters  
+
+* Kraken - Year: 2000, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/66.htm)
+* Manta - Year: 2009, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/67.htm)
+* Ice Breaker - Year: 2022, Status: Operating, Builder: Premier Rides, Type: Steel [RCDB Link](https://rcdb.com/68.htm)
+* Mako - Year: 2016, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/69.htm)
+
+### Kings Dominion (Doswell, Virginia)
+
+16 Coasters
+
+* Apple Zapple - Year: 2003, Status: Operating, Builder: Mack Rides, Type: Steel [RCDB Link](https://rcdb.com/70.htm)
+* Backlot Stunt Coaster - Year: 2005, Status: Operating, Builder: Premier Rides, Type: Steel [RCDB Link](https://rcdb.com/71.htm)
+* Dominator - Year: 2008, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/72.htm)
+* Anaconda - Year: 1991, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/73.htm)
+* Flight of Fear - Year: 1996, Status: Operating, Builder: Premier Rides, Type: Steel [RCDB Link](https://rcdb.com/74.htm)
+* Intimidator 305 - Year: 2010, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/75.htm)
+* Grizzly - Year: 1982, Status: Operating, Builder: Dinn Corporation, Type: Wood [RCDB Link](https://rcdb.com/76.htm)
+* Avalanche - Year: 1988, Status: Operating, Builder: Mack Rides, Type: Steel [RCDB Link](https://rcdb.com/77.htm)
+* Twisted Timbers - Year: 2018, Status: Operating, Builder: Rocky Mountain Construction, Type: Hybrid [RCDB Link](https://rcdb.com/78.htm)
+* Hurler - Year: 1994-2017, Status: Closed, Builder: International Coasters, Type: Wood [RCDB Link](https://rcdb.com/79.htm)
+* Tumbili - Year: 2022, Status: Operating, Builder: S&S Worldwide, Type: Steel [RCDB Link](https://rcdb.com/80.htm)
+* Hypersonic XLC - Year: 2001-2007, Status: Closed, Builder: S&S Worldwide, Type: Steel [RCDB Link](https://rcdb.com/81.htm)
+* Racer 75 - Year: 1975, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/82.htm)
+* Shockwave - Year: 1986-2015, Status: Closed, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/83.htm)
+* Volcano: The Blast Coaster - Year: 1998-2018, Status: Closed, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/84.htm)
+
+### Motorworld (Virginia Beach, Virginia)
+
+* Crazy Mouse - Year: 2000, Status: Operating, Builder: Zamperla, Type: Steel [RCDB Link](https://rcdb.com/85.htm)
+
+### Dollywood (Pigeon Forge, Tennessee)
+
+8 Coasters
+
+* Lightning Rod - Year: 2016, Status: Operating, Builder: Rocky Mountain Construction, Type: Hybrid [RCDB Link](https://rcdb.com/86.htm)
+* Blazing Fury - Year: 1978, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/87.htm)
+* Wild Eagle - Year: 2012, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/88.htm)
+* Firechaser Express - Year: 2014, Status: Operating, Builder: Gerstlauer, Type: Steel [RCDB Link](https://rcdb.com/89.htm)
+* Mystery Mine - Year: 2007, Status: Operating, Builder: Gerstlauer, Type: Steel [RCDB Link](https://rcdb.com/90.htm)
+* Tennessee Tornado - Year: 1999, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/91.htm)
+* Thunderhead - Year: 2004, Status: Operating, Builder: Great Coasters International, Type: Wood [RCDB Link](https://rcdb.com/92.htm)
+* Dragonflier - Year: 2019, Status: Operating, Builder: Vekoma, Type: Steel [RCDB Link](https://rcdb.com/93.htm)
+
+### New York New York (Las Vegas, Nevada)
+
+1 Coaster
+
+* The Big Apple Coaster - Year: 1997, Status: Operating, Builder: Togo, Type: Steel [RCDB Link](https://rcdb.com/94.htm)
+
+### Cedar Point
+
+12 Coasters
+
+* Blue Streak - Year: 1964, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/95.htm)
+* Cedar Creek Mine Ride - Year: 1969, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/96.htm)
+* Corkscrew - Year: 1976, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/97.htm)
+* Gatekeeper - Year: 2013, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/98.htm)
+* Gemini - Year: 1978, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/99.htm)
+* Iron Dragon - Year: 1987, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/100.htm)
+* Magnum XL-200 - Year: 1989, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/101.htm)
+* Maverick - Year: 2007, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/102.htm)
+* Millennium Force - Year: 2000, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/103.htm)
+* Raptor - Year: 1994, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/104.htm)
+* Rougarou - Year: 2015, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/105.htm)
+* Valravn - Year: 2016, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/106.htm)
+
+### Disneyland (California)
+
+3 Coasters
+
+* Big Thunder Mountain Railroad - Year: 1979, Status: Operating, Builder: Walt Disney Imagineering, Type: Steel [RCDB Link](https://rcdb.com/107.htm)
+* Matterhorn Bobsleds - Year: 1959, Status: Operating, Builder: Walt Disney Imagineering, Type: Steel [RCDB Link](https://rcdb.com/108.htm)
+* Space Mountain - Year: 1977, Status: Operating, Builder: Walt Disney Imagineering, Type: Steel [RCDB Link](https://rcdb.com/109.htm)
+
+### Walt Disney World (Magic Kingdom)
+
+3 Coasters
+
+* Space Mountain - Year: 1975, Status: Operating, Builder: Walt Disney Imagineering, Type: Steel [RCDB Link](https://rcdb.com/110.htm)
+* Big Thunder Mountain Railroad - Year: 1980, Status: Operating, Builder: Walt Disney Imagineering, Type: Steel [RCDB Link](https://rcdb.com/111.htm)
+
+### Walt Disney World (Hollywood Studios)
+
+1 Coaster
+
+* Rock 'n' Roller Coaster - Year: 1999, Status: Operating, Builder: Vekoma, Type: Steel [RCDB Link](https://rcdb.com/112.htm)
+
+### Walt Disney World (Animal Kingdom)
+
+1 Coaster
+
+* Expedition Everest - Year: 2006, Status: Operating, Builder: Vekoma, Type: Steel [RCDB Link](https://rcdb.com/113.htm)
+
+### Universal Studios
+
+4 Coasters
+
+* Harry Potter and the Escape from Gringotts - Year: 2014, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/114.htm)
+* Hollywood Rip Ride RockIt - Year: 2009, Status: Operating, Builder: Maurer, Type: Steel [RCDB Link](https://rcdb.com/115.htm)
+* Revenge of the Mummy - Year: 2004, Status: Operating, Builder: Premier Rides, Type: Steel [RCDB Link](https://rcdb.com/116.htm)
+* Woody Woodpecker's Nuthouse Coaster - Year: 1999, Status: Operating, Builder: Vekoma, Type: Steel [RCDB Link](https://rcdb.com/117.htm)
+
+### Universal's Islands of Adventure
+
+6 Coasters
+
+* Flight of the Hippogriff - Year: 2010, Status: Operating, Builder: Vekoma, Type: Steel [RCDB Link](https://rcdb.com/118.htm)
+* Hagrid's Magical Creatures Motorbike Adventure - Year: 2019, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/119.htm)
+* Harry Potter and the Forbidden Journey - Year: 2010, Status: Operating, Builder: Dynamic Structures, Type: Steel [RCDB Link](https://rcdb.com/120.htm)
+* The Incredible Hulk Coaster - Year: 1999, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/121.htm)
+* VelociCoaster - Year: 2021, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/122.htm)
+* Pteranodon Flyers - Year: 1999, Status: Operating, Builder: Vekoma, Type: Steel [RCDB Link](https://rcdb.com/123.htm)
+
+### Worlds of Fun (Kansas City, Missouri)
+
+5 Coasters
+
+* Mamba - Year: 1998, Status: Operating, Builder: Morgan, Type: Steel [RCDB Link](https://rcdb.com/124.htm)
+* Patriot - Year: 2006, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/125.htm)
+* Prowler - Year: 2009, Status: Operating, Builder: Great Coasters International, Type: Wood [RCDB Link](https://rcdb.com/126.htm)
+* Timber Wolf - Year: 1991, Status: Operating, Builder: Dinn Corporation, Type: Wood [RCDB Link](https://rcdb.com/127.htm)
+* Zambezi Zinger - Year: 2023, Status: Operating, Builder: Great Coasters International, Type: Steel [RCDB Link](https://rcdb.com/128.htm)
+
+### Six Flags America (Bowie, Maryland)
+
+6 Coasters
+
+* Firebird - Year: 2019, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/129.htm)
+* Professor Screamore's Skywinder - Year: 2001, Status: Operating, Builder: Zamperla, Type: Steel [RCDB Link](https://rcdb.com/130.htm)
+* Ragin' Cajun - Year: 2012, Status: Operating, Builder: Zamperla, Type: Steel [RCDB Link](https://rcdb.com/131.htm)
+* Roar - Year: 1998, Status: Operating, Builder: Great Coasters International, Type: Wood [RCDB Link](https://rcdb.com/132.htm)
+* Superman - Ride of Steel - Year: 2000, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/133.htm)
+* Wild One - Year: 1917, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/134.htm)
+
+### Kings Island (Mason, Ohio)
+
+11 Coasters
+
+* Banshee - Year: 2014, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/135.htm)
+* The Bat - Year: 1993, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/136.htm)
+* Racer - Year: 1972, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/137.htm)
+* Orion - Year: 2020, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/138.htm)
+* Diamondback - Year: 2009, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/139.htm)
+* The Beast - Year: 1979, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/140.htm)
+* Adventure Express - Year: 1991, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/141.htm)
+* Snoopy's Soap Box Racers - Year: 2000, Status: Operating, Builder: Zamperla, Type: Steel [RCDB Link](https://rcdb.com/142.htm)
+* Woodstock Express - Year: 1972, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/143.htm)
+* Queen City Stunt Coaster - Year: 2000, Status: Operating, Builder: Zamperla, Type: Steel [RCDB Link](https://rcdb.com/144.htm) 

--- a/docs/CoasterDetails.md
+++ b/docs/CoasterDetails.md
@@ -8,7 +8,7 @@ categories:
 excerpt: "Detailed information about my roller coaster credits!"
 ---
 
-Total Coaster Credits: 103
+Total Coaster Credits: 106
 
 ### Track Types
 
@@ -61,164 +61,167 @@ Total Coaster Credits: 103
 
 9 Coasters
 
-* Iron Gwazi - Year: 2022, Status: Operating, Builder: Rocky Mountain Construction, Type: Hybrid [RCDB Link](https://rcdb.com/57.htm)
-* Scorpion - Year: 1980, Status: Operating, Builder: Schwarzkopf, Type: Steel [RCDB Link](https://rcdb.com/58.htm)
-* Kumba - Year: 1993, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/59.htm)
-* Montu - Year: 1996, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/60.htm)
-* Sand Serpent - Year: 2011, Status: Operating, Builder: Mack Rides, Type: Steel [RCDB Link](https://rcdb.com/61.htm)
-* SheiKra - Year: 2005, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/62.htm)
-* Cheetah Hunt - Year: 2011, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/63.htm)
-* Cobra's Curse - Year: 2016, Status: Operating, Builder: Mack Rides, Type: Steel [RCDB Link](https://rcdb.com/64.htm)
-* Tigris - Year: 2019, Status: Operating, Builder: Premier Rides, Type: Steel [RCDB Link](https://rcdb.com/65.htm)
+* Iron Gwazi - Year: 2022, Status: Operating, Builder: Rocky Mountain Construction, Type: Hybrid [RCDB Link](https://rcdb.com/16985.htm)
+* Scorpion - Year: 1980, Status: Operating, Builder: Schwarzkopf, Type: Steel [RCDB Link](https://rcdb.com/95.htm)
+* Kumba - Year: 1993, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/94.htm)
+* Montu - Year: 1996, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/87.htm)
+* Sand Serpent - Year: 2011, Status: Operating, Builder: Mack Rides, Type: Steel [RCDB Link](https://rcdb.com/2595.htm)
+* SheiKra - Year: 2005, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/2662.htm)
+* Cheetah Hunt - Year: 2011, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/9456.htm)
+* Cobra's Curse - Year: 2016, Status: Operating, Builder: Mack Rides, Type: Steel [RCDB Link](https://rcdb.com/12781.htm)
+* Tigris - Year: 2019, Status: Operating, Builder: Premier Rides, Type: Steel [RCDB Link](https://rcdb.com/16607.htm)
 
 ### Seaworld (Orlando, Florida)
 
 4 Coasters  
 
-* Kraken - Year: 2000, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/66.htm)
-* Manta - Year: 2009, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/67.htm)
-* Ice Breaker - Year: 2022, Status: Operating, Builder: Premier Rides, Type: Steel [RCDB Link](https://rcdb.com/68.htm)
-* Mako - Year: 2016, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/69.htm)
+* Kraken - Year: 2000, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/581.htm)
+* Manta - Year: 2009, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/4190.htm)
+* Ice Breaker - Year: 2022, Status: Operating, Builder: Premier Rides, Type: Steel [RCDB Link](https://rcdb.com/17420.htm)
+* Mako - Year: 2016, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/12758.htm)
 
 ### Kings Dominion (Doswell, Virginia)
 
-16 Coasters
+17 Coasters
 
-* Apple Zapple - Year: 2003, Status: Operating, Builder: Mack Rides, Type: Steel [RCDB Link](https://rcdb.com/70.htm)
-* Backlot Stunt Coaster - Year: 2005, Status: Operating, Builder: Premier Rides, Type: Steel [RCDB Link](https://rcdb.com/71.htm)
-* Dominator - Year: 2008, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/72.htm)
-* Anaconda - Year: 1991, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/73.htm)
-* Flight of Fear - Year: 1996, Status: Operating, Builder: Premier Rides, Type: Steel [RCDB Link](https://rcdb.com/74.htm)
-* Intimidator 305 - Year: 2010, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/75.htm)
-* Grizzly - Year: 1982, Status: Operating, Builder: Dinn Corporation, Type: Wood [RCDB Link](https://rcdb.com/76.htm)
-* Avalanche - Year: 1988, Status: Operating, Builder: Mack Rides, Type: Steel [RCDB Link](https://rcdb.com/77.htm)
-* Twisted Timbers - Year: 2018, Status: Operating, Builder: Rocky Mountain Construction, Type: Hybrid [RCDB Link](https://rcdb.com/78.htm)
-* Hurler - Year: 1994-2017, Status: Closed, Builder: International Coasters, Type: Wood [RCDB Link](https://rcdb.com/79.htm)
-* Tumbili - Year: 2022, Status: Operating, Builder: S&S Worldwide, Type: Steel [RCDB Link](https://rcdb.com/80.htm)
-* Hypersonic XLC - Year: 2001-2007, Status: Closed, Builder: S&S Worldwide, Type: Steel [RCDB Link](https://rcdb.com/81.htm)
-* Racer 75 - Year: 1975, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/82.htm)
-* Shockwave - Year: 1986-2015, Status: Closed, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/83.htm)
-* Volcano: The Blast Coaster - Year: 1998-2018, Status: Closed, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/84.htm)
+* Apple Zapple - Year: 2003, Status: Operating, Builder: Mack Rides, Type: Steel [RCDB Link](https://rcdb.com/2389.htm)
+* Backlot Stunt Coaster - Year: 2005, Status: Operating, Builder: Premier Rides, Type: Steel [RCDB Link](https://rcdb.com/3031.htm)
+* Dominator - Year: 2008, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/3815.htm)
+* Anaconda - Year: 1991, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/63.htm)
+* Flight of Fear - Year: 1996, Status: Operating, Builder: Premier Rides, Type: Steel [RCDB Link](https://rcdb.com/33.htm)
+* Intimidator 305 - Year: 2010, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/4520.htm)
+* Grizzly - Year: 1982, Status: Operating, Builder: Dinn Corporation, Type: Wood [RCDB Link](https://rcdb.com/64.htm)
+* Avalanche - Year: 1988, Status: Operating, Builder: Mack Rides, Type: Steel [RCDB Link](https://rcdb.com/66.htm)
+* Twisted Timbers - Year: 2018, Status: Operating, Builder: Rocky Mountain Construction, Type: Hybrid [RCDB Link](https://rcdb.com/15198.htm)
+* Hurler - Year: 1994-2017, Status: Closed, Builder: International Coasters, Type: Wood [RCDB Link](https://rcdb.com/67.htm)
+* Tumbili - Year: 2022, Status: Operating, Builder: S&S Worldwide, Type: Steel [RCDB Link](https://rcdb.com/18260.htm)
+* Hypersonic XLC - Year: 2001-2007, Status: Closed, Builder: S&S Worldwide, Type: Steel [RCDB Link](https://rcdb.com/594.htm)
+* Racer 75 (North) - Year: 1975, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/88.htm)
+* Racer 75 (South) - Year: 1975, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/88.htm)
+* Shockwave - Year: 1986-2015, Status: Closed, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/70.htm)
+* Volcano: The Blast Coaster - Year: 1998-2018, Status: Closed, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/471.htm)
 
 ### Motorworld (Virginia Beach, Virginia)
 
-* Crazy Mouse - Year: 2000, Status: Operating, Builder: Zamperla, Type: Steel [RCDB Link](https://rcdb.com/85.htm)
+* Crazy Mouse - Year: 2000, Status: Operating, Builder: Zamperla, Type: Steel [RCDB Link](https://rcdb.com/541.htm)
 
 ### Dollywood (Pigeon Forge, Tennessee)
 
 8 Coasters
 
-* Lightning Rod - Year: 2016, Status: Operating, Builder: Rocky Mountain Construction, Type: Hybrid [RCDB Link](https://rcdb.com/86.htm)
-* Blazing Fury - Year: 1978, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/87.htm)
-* Wild Eagle - Year: 2012, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/88.htm)
-* Firechaser Express - Year: 2014, Status: Operating, Builder: Gerstlauer, Type: Steel [RCDB Link](https://rcdb.com/89.htm)
-* Mystery Mine - Year: 2007, Status: Operating, Builder: Gerstlauer, Type: Steel [RCDB Link](https://rcdb.com/90.htm)
-* Tennessee Tornado - Year: 1999, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/91.htm)
-* Thunderhead - Year: 2004, Status: Operating, Builder: Great Coasters International, Type: Wood [RCDB Link](https://rcdb.com/92.htm)
-* Dragonflier - Year: 2019, Status: Operating, Builder: Vekoma, Type: Steel [RCDB Link](https://rcdb.com/93.htm)
+* Lightning Rod - Year: 2016, Status: Operating, Builder: Rocky Mountain Construction, Type: Hybrid [RCDB Link](https://rcdb.com/13229.htm)
+* Blazing Fury - Year: 1978, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/219.htm)
+* Wild Eagle - Year: 2012, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/9851.htm)
+* Firechaser Express - Year: 2014, Status: Operating, Builder: Gerstlauer, Type: Steel [RCDB Link](https://rcdb.com/11254.htm)
+* Mystery Mine - Year: 2007, Status: Operating, Builder: Gerstlauer, Type: Steel [RCDB Link](https://rcdb.com/3717.htm)
+* Tennessee Tornado - Year: 1999, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/539.htm)
+* Thunderhead - Year: 2004, Status: Operating, Builder: Great Coasters International, Type: Wood [RCDB Link](https://rcdb.com/2390.htm)
+* Dragonflier - Year: 2019, Status: Operating, Builder: Vekoma, Type: Steel [RCDB Link](https://rcdb.com/16425.htm)
 
 ### New York New York (Las Vegas, Nevada)
 
 1 Coaster
 
-* The Big Apple Coaster - Year: 1997, Status: Operating, Builder: Togo, Type: Steel [RCDB Link](https://rcdb.com/94.htm)
+* The Big Apple Coaster - Year: 1997, Status: Operating, Builder: Togo, Type: Steel [RCDB Link](https://rcdb.com/525.htm)
 
 ### Cedar Point
 
 12 Coasters
 
-* Blue Streak - Year: 1964, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/95.htm)
-* Cedar Creek Mine Ride - Year: 1969, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/96.htm)
-* Corkscrew - Year: 1976, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/97.htm)
-* Gatekeeper - Year: 2013, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/98.htm)
-* Gemini - Year: 1978, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/99.htm)
-* Iron Dragon - Year: 1987, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/100.htm)
-* Magnum XL-200 - Year: 1989, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/101.htm)
-* Maverick - Year: 2007, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/102.htm)
-* Millennium Force - Year: 2000, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/103.htm)
-* Raptor - Year: 1994, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/104.htm)
-* Rougarou - Year: 2015, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/105.htm)
-* Valravn - Year: 2016, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/106.htm)
+* Blue Streak - Year: 1964, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/4.htm)
+* Cedar Creek Mine Ride - Year: 1969, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/5.htm)
+* Corkscrew - Year: 1976, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/6.htm)
+* Gatekeeper - Year: 2013, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/10974.htm)
+* Gemini (Red) - Year: 1978, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/14.htm)
+* Iron Dragon - Year: 1987, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/8.htm)
+* Magnum XL-200 - Year: 1989, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/9.htm)
+* Maverick - Year: 2007, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/3570.htm)
+* Millennium Force - Year: 2000, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/1457.htm)
+* Raptor - Year: 1994, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/11.htm)
+* Rougarou - Year: 2015, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/12574.htm)
+* Valravn - Year: 2016, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/13266.htm)
 
 ### Disneyland (California)
 
 3 Coasters
 
-* Big Thunder Mountain Railroad - Year: 1979, Status: Operating, Builder: Walt Disney Imagineering, Type: Steel [RCDB Link](https://rcdb.com/107.htm)
-* Matterhorn Bobsleds - Year: 1959, Status: Operating, Builder: Walt Disney Imagineering, Type: Steel [RCDB Link](https://rcdb.com/108.htm)
-* Space Mountain - Year: 1977, Status: Operating, Builder: Walt Disney Imagineering, Type: Steel [RCDB Link](https://rcdb.com/109.htm)
+* Big Thunder Mountain Railroad - Year: 1979, Status: Operating, Builder: Walt Disney Imagineering, Type: Steel [RCDB Link](https://rcdb.com/202.htm)
+* Matterhorn Bobsleds - Year: 1959, Status: Operating, Builder: Walt Disney Imagineering, Type: Steel [RCDB Link](https://rcdb.com/200.htm)
+* Space Mountain - Year: 1977, Status: Operating, Builder: Walt Disney Imagineering, Type: Steel [RCDB Link](https://rcdb.com/201.htm)
 
 ### Walt Disney World (Magic Kingdom)
 
-3 Coasters
+4 Coasters
 
-* Space Mountain - Year: 1975, Status: Operating, Builder: Walt Disney Imagineering, Type: Steel [RCDB Link](https://rcdb.com/110.htm)
-* Big Thunder Mountain Railroad - Year: 1980, Status: Operating, Builder: Walt Disney Imagineering, Type: Steel [RCDB Link](https://rcdb.com/111.htm)
+* Space Mountain (Alpha) - Year: 1975, Status: Operating, Builder: Walt Disney Imagineering, Type: Steel [RCDB Link](https://rcdb.com/267.htm)
+* Space Mountain (Omega) - Year: 1975, Status: Operating, Builder: Walt Disney Imagineering, Type: Steel [RCDB Link](https://rcdb.com/267.htm)
+* Big Thunder Mountain Railroad - Year: 1980, Status: Operating, Builder: Walt Disney Imagineering, Type: Steel [RCDB Link](https://rcdb.com/273.htm)
 
 ### Walt Disney World (Hollywood Studios)
 
 1 Coaster
 
-* Rock 'n' Roller Coaster - Year: 1999, Status: Operating, Builder: Vekoma, Type: Steel [RCDB Link](https://rcdb.com/112.htm)
+* Rock 'n' Roller Coaster - Year: 1999, Status: Operating, Builder: Vekoma, Type: Steel [RCDB Link](https://rcdb.com/560.htm)
 
 ### Walt Disney World (Animal Kingdom)
 
 1 Coaster
 
-* Expedition Everest - Year: 2006, Status: Operating, Builder: Vekoma, Type: Steel [RCDB Link](https://rcdb.com/113.htm)
+* Expedition Everest - Year: 2006, Status: Operating, Builder: Vekoma, Type: Steel [RCDB Link](https://rcdb.com/2389.htm)
 
 ### Universal Studios
 
 4 Coasters
 
-* Harry Potter and the Escape from Gringotts - Year: 2014, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/114.htm)
-* Hollywood Rip Ride RockIt - Year: 2009, Status: Operating, Builder: Maurer, Type: Steel [RCDB Link](https://rcdb.com/115.htm)
-* Revenge of the Mummy - Year: 2004, Status: Operating, Builder: Premier Rides, Type: Steel [RCDB Link](https://rcdb.com/116.htm)
-* Woody Woodpecker's Nuthouse Coaster - Year: 1999, Status: Operating, Builder: Vekoma, Type: Steel [RCDB Link](https://rcdb.com/117.htm)
+* Harry Potter and the Escape from Gringotts - Year: 2014, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/11720.htm)
+* Hollywood Rip Ride RockIt - Year: 2009, Status: Operating, Builder: Maurer, Type: Steel [RCDB Link](https://rcdb.com/4329.htm)
+* Revenge of the Mummy - Year: 2004, Status: Operating, Builder: Premier Rides, Type: Steel [RCDB Link](https://rcdb.com/2138.htm)
+* Woody Woodpecker's Nuthouse Coaster - Year: 1999, Status: Operating, Builder: Vekoma, Type: Steel [RCDB Link](https://rcdb.com/847.htm)
 
 ### Universal's Islands of Adventure
 
 6 Coasters
 
-* Flight of the Hippogriff - Year: 2010, Status: Operating, Builder: Vekoma, Type: Steel [RCDB Link](https://rcdb.com/118.htm)
-* Hagrid's Magical Creatures Motorbike Adventure - Year: 2019, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/119.htm)
-* Harry Potter and the Forbidden Journey - Year: 2010, Status: Operating, Builder: Dynamic Structures, Type: Steel [RCDB Link](https://rcdb.com/120.htm)
-* The Incredible Hulk Coaster - Year: 1999, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/121.htm)
-* VelociCoaster - Year: 2021, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/122.htm)
-* Pteranodon Flyers - Year: 1999, Status: Operating, Builder: Vekoma, Type: Steel [RCDB Link](https://rcdb.com/123.htm)
+* Flight of the Hippogriff - Year: 2010, Status: Operating, Builder: Vekoma, Type: Steel [RCDB Link](https://rcdb.com/4542.htm)
+* Hagrid's Magical Creatures Motorbike Adventure - Year: 2019, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/16618.htm)
+* Harry Potter and the Forbidden Journey - Year: 2010, Status: Operating, Builder: Dynamic Structures, Type: Steel [RCDB Link](https://rcdb.com/4541.htm)
+* The Incredible Hulk Coaster - Year: 1999, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/732.htm)
+* VelociCoaster - Year: 2021, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/18027.htm)
+* Pteranodon Flyers - Year: 1999, Status: Operating, Builder: Vekoma, Type: Steel [RCDB Link](https://rcdb.com/734.htm)
 
 ### Worlds of Fun (Kansas City, Missouri)
 
 5 Coasters
 
-* Mamba - Year: 1998, Status: Operating, Builder: Morgan, Type: Steel [RCDB Link](https://rcdb.com/124.htm)
-* Patriot - Year: 2006, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/125.htm)
-* Prowler - Year: 2009, Status: Operating, Builder: Great Coasters International, Type: Wood [RCDB Link](https://rcdb.com/126.htm)
-* Timber Wolf - Year: 1991, Status: Operating, Builder: Dinn Corporation, Type: Wood [RCDB Link](https://rcdb.com/127.htm)
-* Zambezi Zinger - Year: 2023, Status: Operating, Builder: Great Coasters International, Type: Steel [RCDB Link](https://rcdb.com/128.htm)
+* Mamba - Year: 1998, Status: Operating, Builder: Morgan, Type: Steel [RCDB Link](https://rcdb.com/362.htm)
+* Patriot - Year: 2006, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/3256.htm)
+* Prowler - Year: 2009, Status: Operating, Builder: Great Coasters International, Type: Wood [RCDB Link](https://rcdb.com/4347.htm)
+* Timber Wolf - Year: 1991, Status: Operating, Builder: Dinn Corporation, Type: Wood [RCDB Link](https://rcdb.com/47.htm)
+* Zambezi Zinger - Year: 2023, Status: Operating, Builder: Great Coasters International, Type: Steel [RCDB Link](https://rcdb.com/19261.htm)
 
 ### Six Flags America (Bowie, Maryland)
 
 6 Coasters
 
-* Firebird - Year: 2019, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/129.htm)
-* Professor Screamore's Skywinder - Year: 2001, Status: Operating, Builder: Zamperla, Type: Steel [RCDB Link](https://rcdb.com/130.htm)
-* Ragin' Cajun - Year: 2012, Status: Operating, Builder: Zamperla, Type: Steel [RCDB Link](https://rcdb.com/131.htm)
-* Roar - Year: 1998, Status: Operating, Builder: Great Coasters International, Type: Wood [RCDB Link](https://rcdb.com/132.htm)
-* Superman - Ride of Steel - Year: 2000, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/133.htm)
-* Wild One - Year: 1917, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/134.htm)
+* Firebird - Year: 2019, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/2573.htm)
+* Professor Screamore's Skywinder - Year: 2001, Status: Operating, Builder: Zamperla, Type: Steel [RCDB Link](https://rcdb.com/857.htm)
+* Ragin' Cajun - Year: 2012, Status: Operating, Builder: Zamperla, Type: Steel [RCDB Link](https://rcdb.com/10212.htm)
+* Roar - Year: 1998, Status: Operating, Builder: Great Coasters International, Type: Wood [RCDB Link](https://rcdb.com/500.htm)
+* Superman - Ride of Steel - Year: 2000, Status: Operating, Builder: Intamin, Type: Steel [RCDB Link](https://rcdb.com/572.htm)
+* Wild One - Year: 1917, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/197.htm)
 
 ### Kings Island (Mason, Ohio)
 
-11 Coasters
+12 Coasters
 
-* Banshee - Year: 2014, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/135.htm)
-* The Bat - Year: 1993, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/136.htm)
-* Racer - Year: 1972, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/137.htm)
-* Orion - Year: 2020, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/138.htm)
-* Diamondback - Year: 2009, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/139.htm)
-* The Beast - Year: 1979, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/140.htm)
-* Adventure Express - Year: 1991, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/141.htm)
-* Snoopy's Soap Box Racers - Year: 2000, Status: Operating, Builder: Zamperla, Type: Steel [RCDB Link](https://rcdb.com/142.htm)
-* Woodstock Express - Year: 1972, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/143.htm)
-* Queen City Stunt Coaster - Year: 2000, Status: Operating, Builder: Zamperla, Type: Steel [RCDB Link](https://rcdb.com/144.htm) 
+* Banshee - Year: 2014, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/11634.htm)
+* The Bat - Year: 1993, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/73.htm)
+* Racer (Red) - Year: 1972, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/69.htm)
+* Racer (Blue) - Year: 1972, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/69.htm)
+* Orion - Year: 2020, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/17342.htm)
+* Diamondback - Year: 2009, Status: Operating, Builder: Bolliger & Mabillard, Type: Steel [RCDB Link](https://rcdb.com/4173.htm)
+* The Beast - Year: 1979, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/115.htm)
+* Adventure Express - Year: 1991, Status: Operating, Builder: Arrow Dynamics, Type: Steel [RCDB Link](https://rcdb.com/117.htm)
+* Snoopy's Soap Box Racers - Year: 2000, Status: Operating, Builder: Zamperla, Type: Steel [RCDB Link](https://rcdb.com/763.htm)
+* Woodstock Express - Year: 1972, Status: Operating, Builder: Philadelphia Toboggan Coasters, Type: Wood [RCDB Link](https://rcdb.com/120.htm)
+* Queen City Stunt Coaster - Year: 2000, Status: Operating, Builder: Zamperla, Type: Steel [RCDB Link](https://rcdb.com/756.htm)  

--- a/docs/Coasters.md
+++ b/docs/Coasters.md
@@ -116,7 +116,7 @@ Total Coaster Credits: 103
 3 Coasters
 
 * Big THunder Mountain Railroad
-* Matterhorn Bobseld (Tomorrowland)
+* Matterhorn Bobsleds (Tomorrowland)
 * Space Mountain
 
 ### Walt Disney World (Magic Kingdom)
@@ -172,7 +172,7 @@ Total Coaster Credits: 103
 ### Six Flags America (Bowie, Maryland)
 
 * Firebird
-* Professor Sceamore's Skywinder
+* Professor Sceramore's Skywinder
 * Ragin' Cajun
 * Roar
 * Superman - Ride of Steel

--- a/docs/Coasters.md
+++ b/docs/Coasters.md
@@ -1,14 +1,14 @@
 ---
 title: Coaster Credits
 date: 2022-09-06 12:00:00
-updated: 2024-10-14 00:00:00
+updated: 2025-05-05 00:00:00
 permalink: coasters
 categories:
   - Roller Coasters
 excerpt: "Check out my roller coaster credits!"
 ---
 
-Total Coaster Credits: 92
+Total Coaster Credits: 103
 
 ### Busch Gardens Williamsburg (Williamsburg, Virginia)
 
@@ -177,3 +177,19 @@ Total Coaster Credits: 92
 * Roar
 * Superman - Ride of Steel
 * Wild One
+
+## Kings Island (Mason, Ohio)
+
+11 Coasters
+
+* Banshee
+* The Bat
+* Racer (Blue)
+* Racer (Red)
+* Orion
+* Diamondback
+* The Beast (100th Coaster)
+* Adventure Express
+* Snoopy's Soap Box Racers
+* Woodstock Express
+* Queen City Stunt Coaster


### PR DESCRIPTION
This pull request introduces a comprehensive update to the roller coaster documentation, adding detailed coaster statistics and expanding the list of coaster credits. The changes include creating a new `CoasterDetails.md` file with in-depth information about coaster types, manufacturers, and park-specific coaster lists, as well as updating the `Coasters.md` file to reflect the latest coaster credit count and add new entries.

### Additions to Documentation:

* **New `CoasterDetails.md` File**: Introduced a new file with detailed coaster statistics, including track types, manufacturers, and coaster lists for various parks. Each entry includes coaster names, years, statuses, builders, types, and RCDB links for reference.

### Updates to Existing Documentation:

* **`docs/Coasters.md` Updates**:
  - Updated the `Total Coaster Credits` count from 92 to 103.
  - Added a new section for Kings Island, listing 11 coasters, including notable entries like "The Beast (100th Coaster)" and "Racer" variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added a comprehensive "Coaster Details" document cataloging 106 roller coaster credits, organized by type, manufacturer, and park, with detailed information and reference links.
	- Updated the coaster credits count in the main coaster list from 92 to 103 and added a new section for Kings Island, listing 11 additional coasters.
	- Corrected spelling errors in coaster names for improved accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->