### PR TITLE
KI update

### DIFF
--- a/docs/Coasters.md
+++ b/docs/Coasters.md
@@ -8,7 +8,7 @@ categories:
 excerpt: "Check out my roller coaster credits!"
 ---
 
-Total Coaster Credits: 92
+Total Coaster Credits: 105
 
 ### Busch Gardens Williamsburg (Williamsburg, Virginia)
 
@@ -171,9 +171,29 @@ Total Coaster Credits: 92
 
 ### Six Flags America (Bowie, Maryland)
 
+6 Coasters
+
 * Firebird
 * Professor Sceamore's Skywinder
 * Ragin' Cajun
 * Roar
 * Superman - Ride of Steel
 * Wild One
+
+### Kings Island (Mason, Ohio)
+
+13 Coasters
+
+* The Beast (100th!)
+* Banshee
+* Diamondback
+* Orion
+* Adventure Express
+* Racer (Red)
+* Racer (Blue)
+* Queen City Stunt Coaster
+* Woodstock Express
+* The Bat
+* Mystic Timbers
+* Snoopy's Soap Box Racers
+* Invertigo

--- a/docs/Coasters.md
+++ b/docs/Coasters.md
@@ -115,7 +115,7 @@ Total Coaster Credits: 105
 
 3 Coasters
 
-* Big THunder Mountain Railroad
+* Big Thunder Mountain Railroad
 * Matterhorn Bobseld (Tomorrowland)
 * Space Mountain
 
@@ -127,7 +127,7 @@ Total Coaster Credits: 105
 * Space Mountain (Omega)
 * Big Thunder Mountain Railroad
 
-### Walk Disney World (Hollywood Studios)
+### Walt Disney World (Hollywood Studios)
 
 1 Coaster
 


### PR DESCRIPTION
This pull request updates the roller coaster credits in `docs/Coasters.md` to reflect new additions and milestones. The most important changes include increasing the total coaster count, adding a new park section for Kings Island, and listing the specific coasters ridden there.

### Updates to coaster credits:

* Updated the total coaster credits from 92 to 105 to reflect new rides.

### Additions to coaster listings:

* Added a new section for Kings Island (Mason, Ohio) with 13 coasters, including "The Beast" as the 100th coaster milestone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated coaster credits total from 92 to 105.
  - Added a new section for Kings Island with 13 coasters listed.
  - Marked "The Beast" as the 100th coaster.
  - Added a "6 Coasters" heading for Six Flags America.
  - Corrected coaster name "Big Thunder Mountain Railroad" under Disneyland (California).
  - Fixed section title to "Walt Disney World (Hollywood Studios)."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->